### PR TITLE
fix type hint for Dict and Optional argument

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -131,7 +131,7 @@ class Blockchain:
         return self.last_block['index'] + 1
 
     @property
-    def last_block(self) -> Dict[str: Any]:
+    def last_block(self) -> Dict[str, Any]:
         return self.chain[-1]
 
     @staticmethod
@@ -172,8 +172,8 @@ class Blockchain:
         guess = f'{last_proof}{proof}'.encode()
         guess_hash = hashlib.sha256(guess).hexdigest()
         return guess_hash[:4] == "0000"
-    
-    
+
+
     #intialization of the proof
 
 
@@ -203,7 +203,7 @@ def mine():
     )
 
     # Forge the new Block by adding it to the chain
-    block = blockchain.new_block(proof)
+    block = blockchain.new_block(proof, None)
 
     response = {
         'message': "New Block Forged",
@@ -285,14 +285,14 @@ if __name__ == '__main__':
     port = args.port
 
     app.run(host='0.0.0.0', port=port)
-    
-  
+
+
 def newTrans():
     parser.add_argument('-p')
     response = {
         'message': 'Transction had been reverted successfully',
         'total_nodes': list(blockchain.nodes),
     }
-    
-    
-    
+
+
+


### PR DESCRIPTION
Hi I was looking for some simple blockchain projects to get started and found your project. With Python 3.6.2 :: Anaconda custom (64-bit), I made these changes to run the project successfully:

Dict[str: Any] -> Dict[str, Any], reference: https://docs.python.org/3/library/typing.html#typing.Dict
Optional type "is not the same concept as an optinal argument", reference: https://docs.python.org/3/library/typing.html#typing.Optional

I'm not sure if this is the best solution but at least it's working. Happy to hear your comments.